### PR TITLE
Remove extra verbosity from testDataGenerator

### DIFF
--- a/testData/testDataGenerator.pl
+++ b/testData/testDataGenerator.pl
@@ -11,7 +11,6 @@ for (my $i = 0; $i <= 23; $i++ ) {
 	my $fileName = $fileNameBase;
 	# prepend a zero to the single digits
 	$fileName .= ($i < 10 ? "_0".$i : "_".$i);
-	print "$fileName\n";
 	open (my $fileHandle, '>', $fileName);
 	print $fileHandle <<'END';
 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"


### PR DESCRIPTION
The test generator was printing every file that it created. Removed this
unecessary clutter.